### PR TITLE
Feat/pr custom scale docker runtime

### DIFF
--- a/docker-connection-improvements.md
+++ b/docker-connection-improvements.md
@@ -1,0 +1,62 @@
+# Recent Changes Documentation
+
+## Files Modified
+1. docker_runtime.py
+2. async_utils.py
+3. containers.py
+
+## Purpose
+These changes improve the robustness and reliability of Docker container management across multiple hosts, particularly focusing on error handling and connection management.
+
+## Changes Details
+
+### docker_runtime.py
+- Enhanced Docker host connection handling
+- Added proper timeout and retry mechanism
+- Better error logging for connection failures
+- Added connection verification with ping and version checks
+- Improved fallback mechanism to local Docker when remote hosts fail
+
+Purpose: Ensure reliable connection to Docker hosts and graceful fallback when remote hosts are unavailable.
+
+### async_utils.py
+- Added directory creation handling for session metadata
+- Improved error handling for FileNotFoundError
+- Added proper cleanup for async tasks
+- Better exception handling and reporting
+- Fixed GENERAL_TIMEOUT constant definition
+
+Purpose: Handle asynchronous operations more reliably, particularly for session management and file operations.
+
+### containers.py
+- Aligned Docker client handling with docker_runtime.py
+- Added proper connection timeout
+- Enhanced error handling for network issues
+- Improved connection verification
+- Better logging for connection status
+
+Purpose: Ensure consistent container management behavior across different Docker hosts and reliable container cleanup.
+
+## Overall Benefits
+1. More reliable Docker host connections
+2. Better error recovery and fallback mechanisms
+3. Consistent behavior across different components
+4. Improved logging for troubleshooting
+5. Better handling of network issues and timeouts
+
+## Sample Configuration
+```yaml
+services:
+  openhands-app:
+    image: docker.all-hands.dev/all-hands-ai/openhands:0.30
+    container_name: openhands-app
+    pull_policy: always
+    environment:
+      SANDBOX_RUNTIME_CONTAINER_IMAGE: "docker.all-hands.dev/all-hands-ai/runtime:0.30-nikolaik"
+      LOG_ALL_EVENTS: "true"
+      API_REMOTE_DOCKER: "tcp://vm_1:2375,tcp://vm_2:2375"
+
+    volumes:
+      - ~/.openhands-state:/.openhands-state
+    ports:
+      - "3003:3000"

--- a/openhands/runtime/impl/docker/containers.py
+++ b/openhands/runtime/impl/docker/containers.py
@@ -1,19 +1,72 @@
 import docker
+import os
+import json
+import random
+from typing import List
+
+def _get_docker_clients() -> List[docker.DockerClient]:
+    try:
+        from urllib3.exceptions import MaxRetryError
+        from requests.exceptions import ConnectionError, RequestException
+        
+        remote_docker_urls = os.getenv('API_REMOTE_DOCKER', '')
+        try:
+            docker_hosts = json.loads(remote_docker_urls)
+        except Exception:
+            docker_hosts = [url.strip() for url in remote_docker_urls.split(',') if url.strip()]
+            
+        clients = []
+        if not docker_hosts:
+            clients.append(docker.from_env())
+            return clients
+            
+        # Try each host with better error handling
+        all_hosts = list(docker_hosts)
+        random.shuffle(all_hosts)
+        
+        for host in all_hosts:
+            try:
+                client = docker.DockerClient(base_url=host, timeout=5)
+                # Verify connection is working
+                client.ping()
+                client.version()
+                client._selected_docker_host = host
+                clients.append(client)
+                print(f'Successfully connected to Docker host: {host}')
+            except (ConnectionError, MaxRetryError, RequestException) as e:
+                print(f'Failed to connect to Docker host {host}: {str(e)}')
+                continue
+            except Exception as e:
+                print(f'Unexpected error with Docker host {host}: {str(e)}')
+                continue
+                
+        if not clients:
+            print('All remote Docker hosts failed, using local Docker')
+            clients.append(docker.from_env())
+            
+        return clients
+    except Exception as ex:
+        print(f'Docker client initialization failed: {str(ex)}')
+        return [docker.from_env()]
 
 
 def stop_all_containers(prefix: str):
-    docker_client = docker.from_env()
+    clients = _get_docker_clients()
     try:
-        containers = docker_client.containers.list(all=True)
-        for container in containers:
+        for docker_client in clients:
             try:
-                if container.name.startswith(prefix):
-                    container.stop()
-            except docker.errors.APIError:
-                pass
+                containers = docker_client.containers.list(all=True)
+                for container in containers:
+                    try:
+                        if container.name.startswith(prefix):
+                            container.stop()
+                    except (docker.errors.APIError, docker.errors.NotFound):
+                        pass
             except docker.errors.NotFound:
                 pass
-    except docker.errors.NotFound:  # yes, this can happen!
-        pass
     finally:
-        docker_client.close()
+        for client in clients:
+            try:
+                client.close()
+            except:
+                pass


### PR DESCRIPTION
# Recent Changes Documentation

## Files Modified
1. docker_runtime.py
2. async_utils.py
3. containers.py

## Purpose
These changes improve the robustness and reliability of Docker container management across multiple hosts, particularly focusing on error handling and connection management.

## Changes Details

### docker_runtime.py
- Enhanced Docker host connection handling
- Added proper timeout and retry mechanism
- Better error logging for connection failures
- Added connection verification with ping and version checks
- Improved fallback mechanism to local Docker when remote hosts fail

Purpose: Ensure reliable connection to Docker hosts and graceful fallback when remote hosts are unavailable.

### async_utils.py
- Added directory creation handling for session metadata
- Improved error handling for FileNotFoundError
- Added proper cleanup for async tasks
- Better exception handling and reporting
- Fixed GENERAL_TIMEOUT constant definition

Purpose: Handle asynchronous operations more reliably, particularly for session management and file operations.

### containers.py
- Aligned Docker client handling with docker_runtime.py
- Added proper connection timeout
- Enhanced error handling for network issues
- Improved connection verification
- Better logging for connection status

Purpose: Ensure consistent container management behavior across different Docker hosts and reliable container cleanup.

## Overall Benefits
1. More reliable Docker host connections
2. Better error recovery and fallback mechanisms
3. Consistent behavior across different components
4. Improved logging for troubleshooting
5. Better handling of network issues and timeouts

## Sample Configuration
```yaml
services:
  openhands-app:
    image: docker.all-hands.dev/all-hands-ai/openhands:0.30
    container_name: openhands-app
    pull_policy: always
    environment:
      SANDBOX_RUNTIME_CONTAINER_IMAGE: "docker.all-hands.dev/all-hands-ai/runtime:0.30-nikolaik"
      LOG_ALL_EVENTS: "true"
      API_REMOTE_DOCKER: "tcp://vm_1:2375,tcp://vm_2:2375"

    volumes:
      - ~/.openhands-state:/.openhands-state
    ports:
      - "3003:3000"
