### PR TITLE
feat: enhance conversation creation with error handling and user sess…

### DIFF
--- a/frontend/src/api/open-hands.ts
+++ b/frontend/src/api/open-hands.ts
@@ -14,6 +14,7 @@ import {
 } from "./open-hands.types";
 import { openHands } from "./open-hands-axios";
 import { ApiSettings, PostApiSettings } from "#/types/settings";
+import { displayErrorToast } from "#/utils/custom-toast-handlers";
 
 interface VerifySignatureResponse {
   user: {
@@ -240,21 +241,29 @@ class OpenHands {
     initialUserMsg?: string,
     imageUrls?: string[],
     replayJson?: string,
-  ): Promise<Conversation> {
-    const body = {
-      selected_repository: selectedRepository,
-      selected_branch: undefined,
-      initial_user_msg: initialUserMsg,
-      image_urls: imageUrls,
-      replay_json: replayJson,
-    };
+  ): Promise<Conversation | undefined> {
+    try {
+      const body = {
+        selected_repository: selectedRepository,
+        selected_branch: undefined,
+        initial_user_msg: initialUserMsg,
+        image_urls: imageUrls,
+        replay_json: replayJson,
+      };
 
-    const { data } = await openHands.post<Conversation>(
-      "/api/conversations",
-      body,
-    );
+      const { data } = await openHands.post<Conversation>(
+        "/api/conversations",
+        body,
+      );
 
-    return data;
+      return data;
+    } catch (error: any) {
+      displayErrorToast(
+        "response" in error
+          ? (error.response?.data?.detail ?? "Error create new conversation")
+          : "Error create new conversation",
+      );
+    }
   }
 
   static async getConversation(


### PR DESCRIPTION
This pull request includes changes to both the frontend and backend components to handle error scenarios and improve user experience. The most important changes include adding error handling in the frontend API, checking for existing conversations in the backend, and importing necessary modules.

### Frontend changes:
* [`frontend/src/api/open-hands.ts`](diffhunk://#diff-c65e426074e4340c249c7e4b2ca69d2bc8b9e327df1bf3c197868fb773ccaf13R17): Added `displayErrorToast` import to handle error messages.
* [`frontend/src/api/open-hands.ts`](diffhunk://#diff-c65e426074e4340c249c7e4b2ca69d2bc8b9e327df1bf3c197868fb773ccaf13L243-R245): Modified the `createNewConversation` method to return `Promise<Conversation | undefined>` and added a try-catch block to display error toasts on failure. [[1]](diffhunk://#diff-c65e426074e4340c249c7e4b2ca69d2bc8b9e327df1bf3c197868fb773ccaf13L243-R245) [[2]](diffhunk://#diff-c65e426074e4340c249c7e4b2ca69d2bc8b9e327df1bf3c197868fb773ccaf13R260-R266)

### Backend changes:
* [`openhands/server/routes/manage_conversations.py`](diffhunk://#diff-bd7df3830070d1adcb411d3a60d3e56f6182014e7586422cbfc429c4dc6bfee6L4-R4): Imported `HTTPException` to handle HTTP errors.
* [`openhands/server/routes/manage_conversations.py`](diffhunk://#diff-bd7df3830070d1adcb411d3a60d3e56f6182014e7586422cbfc429c4dc6bfee6R63-R73): Added a check in `_create_new_conversation` to prevent users from starting a new conversation if they already have one running, raising an `HTTPException` if this is the case.- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses.**
[Copilot is generating a summary...]