### PR TITLE
feat: add run mode configuration to bypass user activation checks in …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,6 @@ USER_USE_CASE_SAMPLE=0x9b60c97c53e3e8c55c7d32f55c1b518b6ea417f7
 JWT_SECRET=your-secret-key-for-demo-lp-mcp
 # Thesis Auth Server URL
 THESIS_AUTH_SERVER_URL=http://148.113.35.59:3008
+
+# Run Mode (DEV, PROD) 
+RUN_MODE=DEV

--- a/openhands/server/listen.py
+++ b/openhands/server/listen.py
@@ -22,7 +22,9 @@ base_app.mount(
 base_app.middleware('http')(AttachConversationMiddleware(base_app))
 
 # Add middleware to the base app - need to be added before the other middlewares
-base_app.add_middleware(CheckUserActivationMiddleware)
+
+# TODO: If the run mode is DEV, skip the check
+os.getenv('RUN_MODE') != 'DEV' and base_app.add_middleware(CheckUserActivationMiddleware)
 base_app.add_middleware(JWTAuthMiddleware)
 
 

--- a/openhands/server/listen_socket.py
+++ b/openhands/server/listen_socket.py
@@ -105,10 +105,9 @@ async def connect(connection_id: str, environ):
             user_id = payload['user']['publicAddress']
             
             # TODO: If the user is not whitelisted and the run mode is DEV, skip the check
-            if user.whitelisted != UserStatus.WHITELISTED:
-                if os.getenv('RUN_MODE') != 'DEV':
-                    logger.error(f'User not activated: {user_id}')
-                    raise ConnectionRefusedError('User not activated')
+            if user.whitelisted != UserStatus.WHITELISTED and os.getenv('RUN_MODE') != 'DEV':
+                logger.error(f'User not activated: {user_id}')
+                raise ConnectionRefusedError('User not activated')
 
             mnemonic = user.mnemonic
         except jwt.ExpiredSignatureError:

--- a/openhands/server/routes/git.py
+++ b/openhands/server/routes/git.py
@@ -1,3 +1,4 @@
+import os
 from fastapi import APIRouter, Depends, status, Request
 from fastapi.responses import JSONResponse
 from pydantic import SecretStr
@@ -205,7 +206,15 @@ async def get_suggested_tasks(
 async def get_user_status(request: Request):
     """Get the current user's status (activated or non_activated)"""
     user = request.state.user
-    return {
-        'status': "activated" if user.whitelisted == UserStatus.WHITELISTED else "non_activated",
-        'activated': user.whitelisted == UserStatus.WHITELISTED
-    }
+
+    # TODO: If the run mode is DEV, return True to bypass the check
+    if os.getenv('RUN_MODE') == 'DEV':
+        return {
+            'status': "activated",
+            'activated': True
+        }
+    else:
+        return {
+            'status': "activated" if user.whitelisted == UserStatus.WHITELISTED else "non_activated",
+            'activated': user.whitelisted == UserStatus.WHITELISTED
+        }


### PR DESCRIPTION
This pull request introduces a new `RUN_MODE` environment variable to distinguish between development (`DEV`) and production (`PROD`) environments and implements conditional logic based on this mode. The changes primarily focus on bypassing certain user checks in development mode to streamline testing and debugging.

### Environment Configuration Updates:
* Added a new `RUN_MODE` variable in `.env.example` to specify the application mode (`DEV` or `PROD`).

### Middleware Logic Adjustments:
* Modified `listen.py` to conditionally add the `CheckUserActivationMiddleware` only if `RUN_MODE` is not set to `DEV`.

### User Authentication Adjustments:
* Updated `listen_socket.py` to skip the user whitelist check if `RUN_MODE` is set to `DEV`. This ensures smoother testing without requiring user activation.

### API Behavior Adjustments:
* Updated `routes/git.py` to bypass user activation checks in the `get_user_status` function when in development mode, returning an "activated" status by default.

### Codebase Maintenance:
* Added an `import os` statement in `routes/git.py` to support the new environment variable usage.…DEV mode

- Updated .env.example to include RUN_MODE variable.
- Modified listen_socket.py to skip user activation checks if RUN_MODE is set to DEV.
- Adjusted listen.py to conditionally add CheckUserActivationMiddleware based on RUN_MODE.
- Enhanced get_user_status function in git.py to return activated status in DEV mode.

- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses.**
