### PR TITLE
feat: update invitation validation endpoint to use request body

### DIFF
--- a/openhands/server/middleware.py
+++ b/openhands/server/middleware.py
@@ -232,11 +232,11 @@ class CheckUserActivationMiddleware(BaseHTTPMiddleware):
             '/api/options/use-cases/conversations',
             '/api/invitation/',
             '/api/user/status',
+            '/api/invitation/validate',
         ]
 
         self.public_path_patterns = [
             '/api/options/use-cases/conversations/',
-            '/api/invitation/validate/',
         ]
 
     async def dispatch(self, request: Request, call_next):


### PR DESCRIPTION
- Changed the invitation validation endpoint to accept a JSON body containing the invitation code instead of a path parameter.
- Updated middleware to include the new endpoint in the public path patterns.

- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses.**
