### PR TITLE
refactor: change logger level from info to debug for various components

### DIFF
--- a/openhands/agenthub/codeact_agent/codeact_agent.py
+++ b/openhands/agenthub/codeact_agent/codeact_agent.py
@@ -96,7 +96,7 @@ class CodeActAgent(Agent):
         self.system_prompt = system_prompt
         if self.prompt_manager:
             self.prompt_manager.set_system_message(system_prompt)
-        logger.info(
+        logger.debug(
             f'New system prompt: {self.conversation_memory.process_initial_messages()}'
         )
 
@@ -105,7 +105,7 @@ class CodeActAgent(Agent):
         self.user_prompt = user_prompt
         if self.prompt_manager:
             self.prompt_manager.set_user_message(user_prompt)
-        logger.info(
+        logger.debug(
             f'New user prompt: {self.conversation_memory.process_initial_messages()}'
         )
 
@@ -150,7 +150,7 @@ class CodeActAgent(Agent):
             case Condensation(action=condensation_action):
                 return condensation_action
 
-        logger.info(
+        logger.debug(
             f'Processing {len(condensed_history)} events from a total of {len(state.history)} events'
         )
 

--- a/openhands/agenthub/future_trading_agent/future_trading_agent.py
+++ b/openhands/agenthub/future_trading_agent/future_trading_agent.py
@@ -60,7 +60,7 @@ class FutureTradingAgent(Agent):
         self.tools = built_in_tools
 
         # Retrieve the enabled tools
-        logger.info(
+        logger.debug(
             f"TOOLS loaded for TaskSolvingAgent: {', '.join([tool.get('function').get('name') for tool in self.tools])}"
         )
         self.prompt_manager = PromptManager(

--- a/openhands/core/main.py
+++ b/openhands/core/main.py
@@ -97,7 +97,7 @@ async def run_controller(
     if agent is None:
         agent = create_agent(config)
         mcp_tools = await fetch_mcp_tools_from_config(config.dict_mcp_config, sid=sid)
-        logger.info(f'MCP tools: {mcp_tools}')
+        logger.debug(f'MCP tools: {mcp_tools}')
         agent.set_mcp_tools(mcp_tools)
 
     # when the runtime is created, it will be connected and clone the selected repository

--- a/openhands/mcp/client.py
+++ b/openhands/mcp/client.py
@@ -58,8 +58,6 @@ class MCPClient(BaseModel):
             'timeout': timeout,
             'sse_read_timeout': read_timeout,
         }
-        logger.info(f'sid: {sid}')
-        logger.info('Connecting to MCP server')
 
         try:
             async with sse_client(**self._server_params) as (read, write):

--- a/openhands/mcp/utils.py
+++ b/openhands/mcp/utils.py
@@ -129,10 +129,8 @@ async def call_tool_mcp(mcp_clients: list[MCPClient], action: McpAction) -> Obse
     """
     if not mcp_clients:
         raise ValueError('No MCP clients found')
-    logger.info(f'MCP action received: {action}')
     # Find the MCP agent that has the matching tool name
     matching_client = None
-    logger.info(f'MCP action name: {action.name}')
     for client in mcp_clients:
         if action.name in [tool.name for tool in client.tools]:
             matching_client = client

--- a/openhands/server/middleware.py
+++ b/openhands/server/middleware.py
@@ -262,7 +262,6 @@ class CheckUserActivationMiddleware(BaseHTTPMiddleware):
                     return await call_next(request)
 
         user_id = get_user_id(request)
-        logger.info(f'Checking user activation for {user_id}')
         if not user_id:
             return JSONResponse(
                 status_code=status.HTTP_401_UNAUTHORIZED,

--- a/openhands/server/thesis_auth.py
+++ b/openhands/server/thesis_auth.py
@@ -53,7 +53,6 @@ async def get_user_detail_from_thesis_auth_server(
         start_time = time.time()
         response = await thesis_auth_client.get(url, headers=headers)
         end_time = time.time()
-        logger.info(f'Time taken to get user detail: {end_time - start_time} seconds')
     except httpx.RequestError as exc:
         logger.error(f'Request error while getting user detail: {exc}')
         raise HTTPException(status_code=500, detail='Unable to reach auth server')


### PR DESCRIPTION
This pull request focuses on reducing the verbosity of logging across several modules by replacing `logger.info` calls with `logger.debug` or removing non-essential logging statements. These changes aim to streamline log output for better clarity during debugging and production use.

### Logging Level Adjustments:

* **`openhands/agenthub/codeact_agent/codeact_agent.py`:** Changed logging level from `info` to `debug` in methods `set_system_prompt`, `set_user_prompt`, and `step` to reduce verbosity for routine operations. [[1]](diffhunk://#diff-fb21a42dfa5bafc176bbb2a472f01a3cc1b8fefc52fe8f17518a90eafded7fa5L99-R99) [[2]](diffhunk://#diff-fb21a42dfa5bafc176bbb2a472f01a3cc1b8fefc52fe8f17518a90eafded7fa5L108-R108) [[3]](diffhunk://#diff-fb21a42dfa5bafc176bbb2a472f01a3cc1b8fefc52fe8f17518a90eafded7fa5L153-R153)
* **`openhands/agenthub/future_trading_agent/future_trading_agent.py`:** Adjusted logging level from `info` to `debug` in the constructor to minimize log output for tool initialization.
* **`openhands/core/main.py`:** Replaced an `info` log with a `debug` log in `run_controller` for MCP tools initialization.

### Logging Removal:

* **`openhands/mcp/client.py`:** Removed `info` logs related to MCP server connection to avoid redundant logging.
* **`openhands/mcp/utils.py`:** Eliminated `info` logs for MCP action processing to reduce noise in the logs.
* **`openhands/server/middleware.py`:** Removed a log statement checking user activation for a cleaner middleware log.
* **`openhands/server/thesis_auth.py`:** Removed a log measuring the time taken for a user detail request to simplify logs.- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses.**
