### PR TITLE
Add mnemonic parameter to various runtime classes and methods

### DIFF
--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -127,9 +127,11 @@ class Runtime(FileEditRuntimeMixin):
         user_id: str | None = None,
         git_provider_tokens: PROVIDER_TOKEN_TYPE | None = None,
         a2a_manager: A2AManager | None = None,
+        mnemonic: str | None = None,
     ):
         self.sid = sid
         self.event_stream = event_stream
+        self.mnemonic = mnemonic
         self.event_stream.subscribe(
             EventStreamSubscriber.RUNTIME, self.on_event, self.sid
         )

--- a/openhands/runtime/impl/action_execution/action_execution_client.py
+++ b/openhands/runtime/impl/action_execution/action_execution_client.py
@@ -76,6 +76,7 @@ class ActionExecutionClient(Runtime):
         user_id: str | None = None,
         git_provider_tokens: PROVIDER_TOKEN_TYPE | None = None,
         a2a_manager: A2AManager | None = None,
+        mnemonic: str | None = None,
     ):
         self.session = HttpSession()
         self.action_semaphore = threading.Semaphore(1)  # Ensure one action at a time
@@ -95,6 +96,7 @@ class ActionExecutionClient(Runtime):
             user_id,
             git_provider_tokens,
             a2a_manager=a2a_manager,
+            mnemonic=mnemonic,
         )
 
     @abstractmethod
@@ -336,6 +338,7 @@ class ActionExecutionClient(Runtime):
             self.mcp_clients = await create_mcp_clients(
                 self.config.dict_mcp_config,
                 sid=self.sid,
+                mnemonic=self.mnemonic,
             )
         return await call_tool_mcp_handler(self.mcp_clients, action)
 

--- a/openhands/runtime/impl/docker/docker_runtime.py
+++ b/openhands/runtime/impl/docker/docker_runtime.py
@@ -79,6 +79,7 @@ class DockerRuntime(ActionExecutionClient):
         attach_to_existing: bool = False,
         headless_mode: bool = True,
         a2a_manager: A2AManager | None = None,
+        mnemonic: str | None = None,
     ):
         # TODO FIXME: we don't need to close containers when BE shut down. Only users can close the containers by deleting the conversation.
         # if not DockerRuntime._shutdown_listener_id:
@@ -89,6 +90,7 @@ class DockerRuntime(ActionExecutionClient):
         self.config = config
         self._runtime_initialized: bool = False
         self.status_callback = status_callback
+        self.mnemonic = mnemonic
 
         self._host_port = -1
         self._container_port = -1
@@ -127,6 +129,7 @@ class DockerRuntime(ActionExecutionClient):
             attach_to_existing,
             headless_mode,
             a2a_manager=a2a_manager,
+            mnemonic=mnemonic,
         )
 
         # Log runtime_extra_deps after base class initialization so self.sid is available

--- a/openhands/runtime/impl/remote/remote_runtime.py
+++ b/openhands/runtime/impl/remote/remote_runtime.py
@@ -50,6 +50,8 @@ class RemoteRuntime(ActionExecutionClient):
         headless_mode: bool = True,
         user_id: str | None = None,
         git_provider_tokens: PROVIDER_TOKEN_TYPE | None = None,
+        a2a_manager=None,
+        mnemonic: str | None = None,
     ):
         super().__init__(
             config,
@@ -62,6 +64,8 @@ class RemoteRuntime(ActionExecutionClient):
             headless_mode,
             user_id,
             git_provider_tokens,
+            a2a_manager=a2a_manager,
+            mnemonic=mnemonic,
         )
         if self.config.sandbox.api_key is None:
             raise ValueError(

--- a/openhands/server/conversation_manager/standalone_conversation_manager.py
+++ b/openhands/server/conversation_manager/standalone_conversation_manager.py
@@ -316,10 +316,10 @@ class StandaloneConversationManager(ConversationManager):
                     settings,
                     initial_user_msg,
                     replay_json,
-                    mnemonic,
-                    system_prompt,
-                    user_prompt,
-                    mcp_disable,
+                    mnemonic=mnemonic,
+                    system_prompt=system_prompt,
+                    user_prompt=user_prompt,
+                    mcp_disable=mcp_disable,
                 )
             )
             # This does not get added when resuming an existing conversation

--- a/openhands/server/routes/manage_conversations.py
+++ b/openhands/server/routes/manage_conversations.py
@@ -70,6 +70,7 @@ async def _create_new_conversation(
     image_urls: list[str] | None,
     replay_json: str | None,
     attach_convo_id: bool = False,
+    mnemonic: str | None = None,
 ):
     logger.info(
         'Creating conversation',
@@ -152,12 +153,16 @@ async def _create_new_conversation(
             content=user_msg or '',
             image_urls=image_urls or [],
         )
+        
+
     await conversation_manager.maybe_start_agent_loop(
         conversation_id,
         conversation_init_data,
         user_id,
         initial_user_msg=initial_message_action,
         replay_json=replay_json,
+        github_user_id=None,
+        mnemonic=mnemonic,
     )
     logger.info(f'Finished initializing conversation {conversation_id}')
 
@@ -179,6 +184,7 @@ async def new_conversation(request: Request, data: InitSessionRequest):
     image_urls = data.image_urls or []
     replay_json = data.replay_json
     user_id = get_user_id(request)
+    mnemonic = request.state.user.mnemonic
     try:
         # Create conversation with initial message
         conversation_id = await _create_new_conversation(
@@ -189,6 +195,7 @@ async def new_conversation(request: Request, data: InitSessionRequest):
             initial_user_msg,
             image_urls,
             replay_json,
+            mnemonic=mnemonic,
         )
         if conversation_id and user_id is not None:
             await conversation_module._update_conversation_visibility(

--- a/openhands/server/session/agent_session.py
+++ b/openhands/server/session/agent_session.py
@@ -90,6 +90,7 @@ class AgentSession:
         selected_branch: str | None = None,
         initial_message: MessageAction | None = None,
         replay_json: str | None = None,
+        mnemonic: str | None = None,
     ):
         """Starts the Agent session
         Parameters:
@@ -136,6 +137,7 @@ class AgentSession:
                 git_provider_tokens=git_provider_tokens,
                 selected_repository=selected_repository,
                 selected_branch=selected_branch,
+                mnemonic=mnemonic,
             )
             end_time = time.time()
             total_time = end_time - start_time
@@ -280,6 +282,7 @@ class AgentSession:
         git_provider_tokens: PROVIDER_TOKEN_TYPE | None = None,
         selected_repository: Repository | None = None,
         selected_branch: str | None = None,
+        mnemonic: str | None = None,
     ) -> bool:
         """Creates a runtime instance
 
@@ -329,6 +332,7 @@ class AgentSession:
                 attach_to_existing=False,
                 a2a_manager=agent.a2a_manager,
                 env_vars=env_vars,
+                mnemonic=mnemonic,
             )
             end_time = time.time()
             total_time = end_time - start_time

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -196,6 +196,7 @@ class Session:
                 selected_branch=selected_branch,
                 initial_message=initial_message,
                 replay_json=replay_json,
+                mnemonic=mnemonic
             )
             end_time = time.time()
             total_time = end_time - start_time


### PR DESCRIPTION
This pull request introduces a new `mnemonic` parameter across several components of the `openhands` codebase to facilitate its propagation through various runtime and server layers. The changes ensure that the `mnemonic` value is properly initialized, passed, and utilized where necessary.

### Addition of `mnemonic` Parameter

#### Runtime Initialization Updates:
* Added `mnemonic` as an optional parameter in the `__init__` methods of `openhands/runtime/base.py`, `openhands/runtime/impl/action_execution/action_execution_client.py`, `openhands/runtime/impl/docker/docker_runtime.py`, and `openhands/runtime/impl/remote/remote_runtime.py`. The `mnemonic` value is stored as an instance attribute and passed to parent class initializations where applicable. [[1]](diffhunk://#diff-dfad47e657f893ab3f62500695323fea807f6be59e21457264b09bdf9d509ceaR130-R134) [[2]](diffhunk://#diff-ae989230c91d70524621bbf1ffb5eb7f6fbfba62d9371276c5a017bf701bbc81R79) [[3]](diffhunk://#diff-e7bc132f7cd35153d2f58fb060e112ac373c986ae6316869d3b6bf16b1defb16R82) [[4]](diffhunk://#diff-6bf4835c9bb7bc543c52f656119ff39eeed02d47ee3563ec6f494e545761df66R53-R54)

#### Server Updates:
* Incorporated `mnemonic` into server-side functions such as `maybe_start_agent_loop`, `_create_new_conversation`, `new_conversation`, `start`, `_create_runtime`, and `initialize_agent`. This ensures the `mnemonic` value is passed consistently through the server's conversation and session management layers. [[1]](diffhunk://#diff-797e7297a9216d1ed2945f2a8716c3ee749c2ed5a2cb712720eeff28665aab39L319-R322) [[2]](diffhunk://#diff-bd7df3830070d1adcb411d3a60d3e56f6182014e7586422cbfc429c4dc6bfee6R73) [[3]](diffhunk://#diff-bd7df3830070d1adcb411d3a60d3e56f6182014e7586422cbfc429c4dc6bfee6R187) [[4]](diffhunk://#diff-d5a20ddd7eb4a154e36fdf7bb54269390aadb906aea51476cba0bbd5aeefefe6R93) [[5]](diffhunk://#diff-a69af9b37b79761356adfa922b7ddeeaaacf127e0b2f71d3a5dc5b652010d4e1R199)

#### Action Execution Client Updates:
* Updated the `call_tool_mcp` method in `action_execution_client.py` to include the `mnemonic` parameter when creating MCP clients, ensuring it is available for downstream operations.

These changes collectively improve the modularity and extensibility of the codebase by enabling the seamless propagation of the `mnemonic` parameter.- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses.**
[Copilot is generating a summary...]