### PR TITLE
Add citation rules for LLM use of web and X content

### DIFF
--- a/openhands/agenthub/codeact_agent/prompts/system_prompt.j2
+++ b/openhands/agenthub/codeact_agent/prompts/system_prompt.j2
@@ -75,8 +75,8 @@ Only one tool call per step. Combine commands into a single shell/code block whe
 - Result Validation
   - Sanity-check outputs before presenting
 - Reference (only for report)
-  - You must cite the original source URL directly at the end of any claim or quote included in the report.
-  - The citation must appear at the end of the sentence where the information is used, never elsewhere.
+  - Always cite web sources and X URLs when using their content. The citation must appear at the end of the sentence where the information is used, never elsewhere.
+  - You must cite the original source URL and source X url directly at the end of any claim or quote included in the report.
 6. Deliverables
 - Output Format: Final results (reports, code, summaries) are saved in .md format
 - File Naming: Include today's date (YYYY-MM-DD), e.g., analysis_2025-04-24.md

--- a/openhands/agenthub/codeact_agent/prompts/system_prompt.j2
+++ b/openhands/agenthub/codeact_agent/prompts/system_prompt.j2
@@ -74,14 +74,30 @@ Only one tool call per step. Combine commands into a single shell/code block whe
   - Track source, cleaning steps, and assumptions
 - Result Validation
   - Sanity-check outputs before presenting
+- Reference (only for report)
+  - You must cite the original source URL directly at the end of any claim or quote included in the report.
+  - The citation must appear at the end of the sentence where the information is used, never elsewhere.
 6. Deliverables
 - Output Format: Final results (reports, code, summaries) are saved in .md format
 - File Naming: Include today's date (YYYY-MM-DD), e.g., analysis_2025-04-24.md
 - Date Stamp: Start each report with Date
 - Versioning: Archive prior versions (e.g., _v1, _2025-04-24T1530Z) in an /archive folder before updating
+- Citation Format:
+  Add a source citation (with the form [Anchor Text](https://source-url.com)) immediately after any factual statement, quote, or claim taken from an external source.
+  Citations should be placed inline, typically at the end of the sentence or bullet point.
 7. User sessions
 - User sessions are identified by a <session_id>.
 - Use user session id when needed when working with workspace in format /workspace/<session_id>
+
+8. Reference Integration (in Report)
+- Only include a source link when using content, data, or analysis from that specific website.
+- Integrate web references naturally within your writing, rather than listing them separately. Do not list sources in a separate final section; instead, cite the URL directly within the sentence where the web content is used.
+- All citations must appear at the end of the sentence they refer to, and must strictly follow the Markdown format: [Anchor Text](https://source-url.com)
+- This is mandatory: any sentence using information from a web URL must end with a proper Markdown citation.
+- The anchor text should be concise and relevant (e.g., name of the source or article title).
+- Avoid raw URLs like https://source-url.com unless explicitly required.
+- Example 1: As highlighted in [Electric Capital’s 2024 Developer Report](https://www.electriccapital.com/developer-report), the number of active open-source developers in the Web3 ecosystem has steadily declined since mid-2022, despite continued interest in Layer 2 technologies.
+- Example 2: Trump has asked Attorney General Pam Bondi to "produce any and all pertinent grand jury testimony" in the Jeffrey Epstein case [AP news](https://apnews.com/hub/donald-trump)
 
 {% if agent_infos %}
 <A2A_INFO>


### PR DESCRIPTION
This PR updates the system prompt used by CodeAct agent to enforce stricter and clearer citation rules for content taken from websites and X (formerly Twitter).